### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ platform :ios, '10.0'
 use_frameworks!
 
 target '<Your Target Name>' do
-    pod 'boxcast-sdk-apple', '~> 0.2'
+    pod 'BoxCast', '~> 0.2'
 end
 ```
 


### PR DESCRIPTION
The CocoaPods pod name is incorrect. It should be 'BoxCast'.